### PR TITLE
Update PLAnT-ISCE3 to v0.0.8

### DIFF
--- a/src/plant_isce3/plant_isce3_geocode.py
+++ b/src/plant_isce3/plant_isce3_geocode.py
@@ -186,11 +186,9 @@ class PlantIsce3Geocode(plant_isce3.PlantIsce3Script):
 
         if (plant_product_obj.sensor_name == 'Sentinel-1'):
 
-            for burst in plant_product_obj.burst_list:
-                temp_vrt = plant.get_temporary_file(ext='vrt')
-                burst.slc_to_vrt_file(temp_vrt)
-                input_raster = temp_vrt
-                break
+            input_raster = plant_product_obj.get_sentinel_1_input_raster(
+                self.input_raster,
+                flag_transform_input_raster=self.flag_transform_input_raster)
 
         else:
             ret_dict = self._get_input_raster_from_nisar_slc(

--- a/src/plant_isce3/plant_isce3_runconfig.py
+++ b/src/plant_isce3/plant_isce3_runconfig.py
@@ -42,14 +42,6 @@ def get_parser():
                         action='store_true',
                         help='Use default runconfig.')
 
-    parser.add_argument('--standard',
-                        '--nisar', '--standard-product',
-                        '--nisar-standard',
-                        dest='flag_standard_product',
-                        default=False,
-                        action='store_true',
-                        help='Generate standard NISAR product.')
-
     parser.add_argument('--sas-output-file',
                         '--sas-of',
                         dest='sas_output_file',
@@ -60,6 +52,29 @@ def get_parser():
                         action='store_true',
                         dest='flag_gslc',
                         help='Generated geocoded SLC runconfig')
+
+    parser.add_argument(
+        '--rtc-min-value-db',
+        dest='rtc_min_value_db',
+        default=-30,
+        type=float,
+        help=(
+            'Minimum RTC area normalization factor (AFN) in'
+            ' dB. "nan" to disable it (default: %(default)s)'))
+
+    parser.add_argument('--mantissa-nbits',
+                        '--mantissa-n-bits',
+                        '--mantissa-number-bits',
+                        '--mantissa-number-of-bits',
+                        dest='mantissa_nbits',
+                        default=16,
+                        type=int,
+                        help=('Number of bits retained in the mantissa'
+                              ' of the floating point representation of each'
+                              ' component real and imaginary (if applicable)'
+                              ' of each output sample.'
+                              ' Any negative number disables the mantissa bits'
+                              ' truncation (default: %(default)s)'))
 
     parser.add_argument('--snap-x',
                         dest='snap_x',
@@ -360,16 +375,22 @@ class PlantIsce3Runconfig(plant_isce3.PlantIsce3Script):
         print('        primary_executable:', **kwargs)
         print(f'            product_type: {workflow_name_upper}', **kwargs)
 
-        if workflow_name_upper == 'GCOV' and self.flag_standard_product:
+        if (workflow_name_upper == 'GCOV' and
+                self.mantissa_nbits is not None and
+                self.mantissa_nbits >= 0):
             print('        output:', **kwargs)
             print('            output_gcov_terms:', **kwargs)
-            print('                mantissa_nbits: 16', **kwargs)
+            print(f'                mantissa_nbits: {self.mantissa_nbits}',
+                  **kwargs)
 
         print('        processing:', **kwargs)
 
-        if workflow_name_upper == 'GCOV' and self.flag_standard_product:
+        if (workflow_name_upper == 'GCOV' and
+                self.rtc_min_value_db is not None and
+                plant.isvalid(self.rtc_min_value_db)):
             print('            rtc:', **kwargs)
-            print('                rtc_min_value_db: -30', **kwargs)
+            print(f'                rtc_min_value_db: {self.rtc_min_value_db}',
+                  **kwargs)
 
         print('            geocode:', **kwargs)
 

--- a/src/plant_isce3/plant_isce3_util.py
+++ b/src/plant_isce3/plant_isce3_util.py
@@ -132,7 +132,7 @@ class PlantIsce3Util(plant_isce3.PlantIsce3Script):
             self.print('Operation cancelled.', 1)
             return
 
-        if (not self.input_file.endswith('.h5') and not
+        if (not self.input_file.endswith('.h5') and
                 not self.input_file.endswith('.nc')):
 
             image_obj = plant.read_image(self.input_file)

--- a/src/plant_isce3/version.py
+++ b/src/plant_isce3/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.0.7'
+VERSION = '0.0.8'


### PR DESCRIPTION
Update PLAnT-ISCE3 to v0.0.8:
- Update `plant_isce3_rtc.py` to process Sentinel-1 datasets;
- Add arguments `--rtc-min-value-db` and `--mantissa-nbits` to `plant_isce3_runconfig.py`;
- Fix minor bugs.