### PR TITLE
Hardcode `setuptools_scm` version `8.3.1`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64.0", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=77.0", "setuptools_scm[toml]==8.3.1"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
This PR hardcodes the `setuptools_scm` version  to`8.3.1`.