### PR TITLE
More updates to PLAnT-ISCE3 v0.1.5

### DIFF
--- a/src/plant_isce3/plant_isce3_filter.py
+++ b/src/plant_isce3/plant_isce3_filter.py
@@ -123,12 +123,13 @@ class PlantIsce3Filter(plant_isce3.PlantIsce3Script):
         plant_isce3.multilook_isce3(input_raster, self.output_file,
                                     self.nlooks_az, self.nlooks_rg,
                                     transform_square=self.transform_square,
+                                    output_format=self.output_format,
                                     block_nlines=self.block_nlines)
 
         ret_dict = {}
         ret_dict['output_file'] = self.output_file
         plant.append_output_file(self.output_file)
-        self.update_output_format(ret_dict)
+        plant_isce3.update_output_format(ret_dict)
 
         return self.output_file
 

--- a/src/plant_isce3/plant_isce3_geocode.py
+++ b/src/plant_isce3/plant_isce3_geocode.py
@@ -313,7 +313,7 @@ class PlantIsce3Geocode(plant_isce3.PlantIsce3Script):
         if self.geogrid_upsampling is None:
             self.geogrid_upsampling = 1
 
-        isce3_temporary_format = self.get_isce3_temporary_format(
+        isce3_temporary_format = plant_isce3.get_isce3_temporary_format(
             self.output_file)
 
         output_raster_obj = plant_isce3.get_isce3_raster(
@@ -616,7 +616,7 @@ class PlantIsce3Geocode(plant_isce3.PlantIsce3Script):
         if self.covariance_matrix:
             self._generate_cov_matrix(frequency_str)
 
-        self.update_output_format(ret_dict)
+        plant_isce3.update_output_format(ret_dict)
 
         return self.output_file
 

--- a/src/plant_isce3/plant_isce3_util.py
+++ b/src/plant_isce3/plant_isce3_util.py
@@ -677,6 +677,7 @@ class PlantIsce3Util(plant_isce3.PlantIsce3Script):
             temp_file = plant.get_temporary_file(ext='.tif', append=True)
             plant_isce3.multilook_isce3(image_ref,
                                         output_file=temp_file,
+                                        output_format=self.output_format,
                                         nlooks_y=self.nlooks_az,
                                         nlooks_x=self.nlooks_rg)
 


### PR DESCRIPTION
Changes:
- Disable multilooking when `nlooks_x` and `nlooks_y` are set to `1`.
- Fixed data format of the multilooked temporary file.