### PR TITLE
Ensure that extension is not added with two dots

### DIFF
--- a/src/plant_isce3/plant_isce3_filter.py
+++ b/src/plant_isce3/plant_isce3_filter.py
@@ -95,7 +95,7 @@ class PlantIsce3Filter(plant_isce3.PlantIsce3Script):
     def run(self):
 
         if not self.output_ext:
-            self.output_ext = 'tif'
+            self.output_ext = '.tif'
 
         if self.separate_pol or self.separate_freq:
 

--- a/src/plant_isce3/plant_isce3_filter.py
+++ b/src/plant_isce3/plant_isce3_filter.py
@@ -95,7 +95,7 @@ class PlantIsce3Filter(plant_isce3.PlantIsce3Script):
     def run(self):
 
         if not self.output_ext:
-            self.output_ext = '.tif'
+            self.output_ext = 'tif'
 
         if self.separate_pol or self.separate_freq:
 
@@ -124,6 +124,9 @@ class PlantIsce3Filter(plant_isce3.PlantIsce3Script):
 
             if output_file_orig:
                 self.print(f'## output file template: {output_file_orig}')
+
+            if not self.output_ext.startswith('.'):
+                self.output_ext = f'.{self.output_ext}'
 
             ret_list = []
             for freq, pols in freqs_iterator:


### PR DESCRIPTION
This PR updates `plant_isce3_filter.py` ensuring that extension is not added to the output files with two dots.