### PR TITLE
Include boto3 in the list of dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ h5py
 libgdal-hdf5
 libgdal-netcdf
 libnetcdf
+boto3


### PR DESCRIPTION
This PR includes `boto3` in the list of dependencies.